### PR TITLE
Add DiscordError class for handling custom errors

### DIFF
--- a/src/customSolutions/gangstaPhilosophy/index.ts
+++ b/src/customSolutions/gangstaPhilosophy/index.ts
@@ -6,7 +6,7 @@ import {
     addOrUpdateSubscriber,
     getSubscriber,
 } from "../customIntegrations/tagMango/services/attackMode.service";
-import { DiscordError } from "@/types/error/discord-error";
+import { DiscordError } from "@/types/error";
 
 router.get("/", async (req, res) => {
     res.send("Welcome to Gangsta Philosophy!");

--- a/src/types/error/discord-error.ts
+++ b/src/types/error/discord-error.ts
@@ -1,0 +1,7 @@
+export class DiscordError extends Error {
+    show: boolean;
+    constructor(message: string, show: boolean) {
+        super(message);
+        this.show = show;
+    }
+}

--- a/src/types/error/index.ts
+++ b/src/types/error/index.ts
@@ -1,2 +1,3 @@
 export * from "./controller-error";
 export * from "./service-error";
+export * from "./discord-error";


### PR DESCRIPTION
This pull request adds a new class called DiscordError that extends the Error class. It is used for handling custom errors related to Discord integration. The class has a property called "show" which determines whether the error should be displayed to the user or not. This class is used in the subscriberValidator function to throw specific errors when certain conditions are not met.